### PR TITLE
Support alpha transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Subscribes to camera images and 3D markers and republishes the image with marker
 
 Run:
 
-    rosrun marker_on_image marker_on_image_node _in_marker_topic:="/some_markers" _in_image_topic:="/some/camera" _out_image_topic:="/some_image"
+    rosrun marker_on_image marker_on_image_node _in_marker_topic:="/some_markers" _in_image_topic:="/some/camera" _out_image_topic:="/some_image" _alpha:=0.3
 
 ## Supported
 
@@ -18,6 +18,15 @@ Types:
 Actions:
 
 * `ADD`
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `in_marker_topic` | string | `markers` | Topic to receive markers (`visualization_msgs/MarkerArray`) |
+| `in_image_topic` | string | `camera/rgb/image_raw` | Topic to receive camera images (`sensor_msgs/Image` and `sensor_msgs/CameraInfo`) |
+| `out_image_topic` | string | `camera/rgb/image_markers` | Topic to publish images with overlayed markers (`sensor_msgs/Image`) |
+| `alpha` | double | -1 | Alpha to be applied to all markers. If not set (< 0), the alpha from each marker message will be used. |
 
 ## TODO
 


### PR DESCRIPTION
By default, use the transparency from each marker message. Optionally, an alpha can be set for all markers.